### PR TITLE
Fix color generation formatting

### DIFF
--- a/openseamap.py
+++ b/openseamap.py
@@ -68,7 +68,11 @@ def speed_to_color(speed: float, max_speed: float) -> str:
     norm_speed = min(speed / max_speed, 1.0)
     # norm_speed = min(speed / max(1,max_speed), 1.0)
     color = plt.cm.RdYlGn(norm_speed)
-    return f"#{int(color[0] * 255):x}{int(color[1] * 255):x}{int(color[2] * 255):x}"
+    return (
+        f"#{int(color[0] * 255):02x}"
+        f"{int(color[1] * 255):02x}"
+        f"{int(color[2] * 255):02x}"
+    )
 
 
 def create_map(gpx_files: List[str], names: List[str], max_speed: float) -> Tuple[folium.Map, List[List], float, str]:

--- a/tests/test_openseamap.py
+++ b/tests/test_openseamap.py
@@ -42,7 +42,11 @@ def test_speed_to_color():
     for speed in speeds:
         color = speed_to_color(speed, max_speed)
         assert isinstance(color, str)
+        assert color.startswith("#")
+        assert len(color) == 7
 
     # Test speed exceeding max_speed
     color = speed_to_color(15, max_speed)
     assert isinstance(color, str)
+    assert color.startswith("#")
+    assert len(color) == 7


### PR DESCRIPTION
## Summary
- fix 6-digit hex color formatting in `speed_to_color`
- test color format to ensure strings are 6-digit hex values

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459422423c8320adc03106468be9dd