### PR TITLE
Add wind overlay foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ data/
 run.json
 .aider*
 .env
+__pycache__/
+tests/__pycache__/

--- a/animate_tracks.js
+++ b/animate_tracks.js
@@ -13,10 +13,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const map = window[map_id];
 
     const trackMarkers = initializeTrackMarkers(map);
+    if (typeof initWindToggle === 'function') {
+        initWindToggle(map);
+    }
 
     slider.addEventListener('input', () => {
         updateTrackMarkers(slider, trackMarkers);
         updateTimeDisplay(slider, timeLegend);
+        const timeIndex = Math.floor(slider.value / 1000 * (gpx_timestamps.length - 1));
+        const currentTime = gpx_timestamps[timeIndex];
+        if (typeof updateWindLayer === 'function') {
+            updateWindLayer(currentTime, map);
+        }
     });
 
     // Initialize with the first timestamp

--- a/openseamap.py
+++ b/openseamap.py
@@ -154,6 +154,7 @@ def add_animation(folium_map: folium.Map,
     </script>
     <script>                                                                                                                                                                                                                       
     {open('animate_tracks.js', encoding='UTF-8').read()}                                                                                                                                                                                             
+    {open("wind_layer.js", encoding="UTF-8").read()}
     </script>
     """
     folium_map.get_root().html.add_child(folium.Element(animation_script))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
   "lxml",
   "numpy",
   "gpxpy",
+  "httpx",
+  "diskcache",
+  "pytest-asyncio",
 ]
 
 [project.scripts]              # CLI entry-points after `pip install gpx-player`
@@ -26,5 +29,5 @@ gpx-player  = "main:main"
 gpx-validate = "validator:main"
 
 [tool.setuptools]
-py-modules = ["main", "openseamap", "gpx_utils", "utils", "validator"]
+py-modules = ["main", "openseamap", "gpx_utils", "utils", "validator", "wind.source_openmeteo", "wind.cache"]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ dependencies = [
   "gpxpy",
   "httpx",
   "diskcache",
+  "fastapi",
   "pytest-asyncio",
+  "uvicorn",
 ]
 
 [project.scripts]              # CLI entry-points after `pip install gpx-player`
@@ -29,5 +31,14 @@ gpx-player  = "main:main"
 gpx-validate = "validator:main"
 
 [tool.setuptools]
-py-modules = ["main", "openseamap", "gpx_utils", "utils", "validator", "wind.source_openmeteo", "wind.cache"]
+py-modules = [
+    "main",
+    "openseamap",
+    "gpx_utils",
+    "utils",
+    "validator",
+    "wind.source_openmeteo",
+    "wind.cache",
+    "wind.server",
+]
 include-package-data = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 diskcache
+fastapi
 folium
 gpxpy
 httpx
@@ -10,3 +11,4 @@ pytest
 pytest-asyncio
 pytest-cov
 pytz
+uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
-gpxpy
+diskcache
 folium
+gpxpy
+httpx
 jinja2
 lxml
 matplotlib
 numpy
-pytest-cov
 pytest
+pytest-asyncio
+pytest-cov
 pytz

--- a/tests/test_wind_openmeteo.py
+++ b/tests/test_wind_openmeteo.py
@@ -1,0 +1,43 @@
+import asyncio
+import datetime as dt
+from wind.source_openmeteo import OpenMeteoSource
+from wind import BBox, WindGrid
+
+import pytest
+from unittest.mock import patch, AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_openmeteo_grid():
+    src = OpenMeteoSource()
+    bbox = BBox(west=0, south=0, east=1, north=1)
+    t0 = dt.datetime(2024,1,1, tzinfo=dt.timezone.utc)
+    t1 = dt.datetime(2024,1,2, tzinfo=dt.timezone.utc)
+
+    fake_json = {
+        "latitude": [0, 1],
+        "longitude": [0, 1],
+        "hourly": {
+            "time": ["2024-01-01T00:00:00Z", "2024-01-01T01:00:00Z"],
+            "u10": [[0, 0],[0,0]],
+            "v10": [[0, 0],[0,0]]
+        }
+    }
+
+    async def fake_get(url, params=None):
+        class Resp:
+            status_code = 200
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return fake_json
+        return Resp()
+
+    with patch('httpx.AsyncClient.get', new=AsyncMock(side_effect=fake_get)):
+        grid = await src.grid(bbox, t0, t1)
+
+    assert isinstance(grid, WindGrid)
+    assert grid.nx == 2
+    assert grid.ny == 2
+    assert len(grid.times) == 2
+

--- a/tests/test_wind_server.py
+++ b/tests/test_wind_server.py
@@ -1,0 +1,41 @@
+import datetime as dt
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from wind.server import app, src, cache
+from wind import WindGrid
+
+
+@pytest.mark.asyncio
+async def test_wind_endpoint():
+    fake_grid = WindGrid(
+        u=[[0.0]],
+        v=[[0.0]],
+        nx=1,
+        ny=1,
+        lo1=0.0,
+        la1=0.0,
+        dx=1.0,
+        dy=1.0,
+        times=[dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)],
+    )
+
+    with patch.object(src, "grid", AsyncMock(return_value=fake_grid)):
+        with patch.object(cache, "get", return_value=None), patch.object(cache, "set") as set_mock:
+            params = {
+                "time": "2024-01-01T00:00:00+00:00",
+                "west": 0,
+                "south": 0,
+                "east": 1,
+                "north": 1,
+            }
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+                resp = await ac.get("/wind", params=params)
+
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["nx"] == 1
+            assert set_mock.called

--- a/wind/__init__.py
+++ b/wind/__init__.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol, List
+
+@dataclass
+class BBox:
+    west: float
+    south: float
+    east: float
+    north: float
+
+@dataclass
+class WindGrid:
+    u: List[List[float]]
+    v: List[List[float]]
+    nx: int
+    ny: int
+    lo1: float
+    la1: float
+    dx: float
+    dy: float
+    times: List[datetime]
+
+@dataclass
+class TiledEndpoint:
+    url: str
+
+class WindSource(Protocol):
+    async def grid(self, bbox: BBox, t0: datetime, t1: datetime, level: int = 10) -> WindGrid | TiledEndpoint:
+        ...

--- a/wind/cache.py
+++ b/wind/cache.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from hashlib import sha1
+from pathlib import Path
+from typing import Any
+
+from diskcache import Cache
+
+
+class WindCache:
+    def __init__(self, path: str | Path = "~/.cache/gpx-player/wind", size_limit: int = 1_000_000_000) -> None:
+        self.cache = Cache(Path(path).expanduser(), size_limit=size_limit)
+
+    def _key(self, key: str) -> str:
+        return sha1(key.encode()).hexdigest()
+
+    def get(self, key: str) -> Any:
+        return self.cache.get(self._key(key))
+
+    def set(self, key: str, value: Any, expire: int | None = None) -> None:
+        self.cache.set(self._key(key), value, expire=expire)

--- a/wind/server.py
+++ b/wind/server.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import datetime as dt
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+
+from . import BBox
+from .source_openmeteo import OpenMeteoSource
+from .cache import WindCache
+
+app = FastAPI()
+
+src = OpenMeteoSource()
+cache = WindCache()
+
+@app.get("/wind")
+async def wind(
+    time: str,
+    west: float,
+    south: float,
+    east: float,
+    north: float,
+):
+    """Return Leaflet-Velocity compatible wind JSON."""
+    try:
+        t = dt.datetime.fromisoformat(time)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid time") from exc
+
+    bbox = BBox(west=west, south=south, east=east, north=north)
+    key = f"{time}_{west}_{south}_{east}_{north}"
+    cached = cache.get(key)
+    if cached is not None:
+        return JSONResponse(cached)
+
+    try:
+        grid = await src.grid(bbox, t, t)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Wind data not available") from exc
+
+    result = {
+        "u": grid.u,
+        "v": grid.v,
+        "nx": grid.nx,
+        "ny": grid.ny,
+        "lo1": grid.lo1,
+        "la1": grid.la1,
+        "dx": grid.dx,
+        "dy": grid.dy,
+        "times": [tm.isoformat() for tm in grid.times],
+    }
+    cache.set(key, result, expire=3600)
+    return JSONResponse(result)
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/wind/source_openmeteo.py
+++ b/wind/source_openmeteo.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import httpx
+
+from . import BBox, WindGrid, TiledEndpoint, WindSource
+
+
+class OpenMeteoSource:
+    """Fetch wind data from the Open-Meteo API."""
+
+    FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
+    ERA5_URL = "https://api.open-meteo.com/v1/era5"
+
+    def __init__(self, fresh_threshold_h: int = 72) -> None:
+        self.fresh_threshold = dt.timedelta(hours=fresh_threshold_h)
+
+    async def grid(self, bbox: BBox, t0: dt.datetime, t1: dt.datetime, level: int = 10) -> WindGrid:
+        now = dt.datetime.now(dt.timezone.utc)
+        url = self.FORECAST_URL if (now - t1) < self.fresh_threshold else self.ERA5_URL
+
+        params = {
+            "latitude_min": bbox.south,
+            "latitude_max": bbox.north,
+            "longitude_min": bbox.west,
+            "longitude_max": bbox.east,
+            "hourly": "u10,v10",
+            "start_date": t0.strftime("%Y-%m-%d"),
+            "end_date": t1.strftime("%Y-%m-%d"),
+            "timezone": "UTC",
+        }
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=params)
+            if resp.status_code == 404:
+                raise FileNotFoundError("Wind data not available")
+            resp.raise_for_status()
+            data: Any = resp.json()
+
+        lats = data.get("latitude")
+        lons = data.get("longitude")
+        times = [dt.datetime.fromisoformat(t) for t in data["hourly"]["time"]]
+        u = data["hourly"]["u10"]
+        v = data["hourly"]["v10"]
+
+        nx = len(lons)
+        ny = len(lats)
+        dx = abs(lons[1] - lons[0]) if nx > 1 else 0.0
+        dy = abs(lats[1] - lats[0]) if ny > 1 else 0.0
+
+        return WindGrid(u=u, v=v, nx=nx, ny=ny, lo1=lons[0], la1=lats[0], dx=dx, dy=dy, times=times)

--- a/wind_layer.js
+++ b/wind_layer.js
@@ -1,0 +1,34 @@
+let windLayer;
+let windEnabled = false;
+
+function initWindToggle(map) {
+    const control = L.control({ position: 'topright' });
+    control.onAdd = function () {
+        const btn = L.DomUtil.create('button', 'wind-toggle');
+        btn.innerHTML = '⚡';
+        btn.title = 'Toggle wind';
+        btn.onclick = () => {
+            windEnabled = !windEnabled;
+            btn.style.background = windEnabled ? 'gray' : '';
+            if (!windEnabled && windLayer) {
+                map.removeLayer(windLayer);
+                windLayer = undefined;
+            }
+        };
+        return btn;
+    };
+    control.addTo(map);
+}
+
+async function updateWindLayer(timestamp, map) {
+    if (!windEnabled) return;
+    try {
+        const resp = await fetch(`/wind?time=${encodeURIComponent(timestamp)}`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        if (windLayer) map.removeLayer(windLayer);
+        windLayer = L.velocityLayer({ data, maxVelocity: 25, velocityScale: 0.005 }).addTo(map);
+    } catch (e) {
+        console.error('wind error', e);
+    }
+}


### PR DESCRIPTION
## Summary
- define basic wind API types and OpenMeteo adapter
- add diskcache-based wind cache
- integrate wind JS layer with playback
- include new JS in generated HTML
- test OpenMeteo adapter
- update dependencies and gitignore
- sort requirements alphabetically

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845e34888508320b1a2365f44a1f6f2